### PR TITLE
Allow empty segments

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -1090,12 +1090,15 @@ nextSegment ps =
         (r,_)       -> (r,[])
 
 segments :: String -> [String]
-segments = unfoldr nextSegmentMaybe
+segments str = case str of
+    ('/':str1) -> unfoldr nextSegmentMaybe str1 --So we don't get an beginning empty segment
+    str1 -> unfoldr nextSegmentMaybe str1
     where
         nextSegmentMaybe ps =
-            case break (=='/') ({- Get rid of empty segments -} snd $ break (/='/') ps) of
-                (r,'/':ps1) -> Just (r,ps1)
-                (_,_)       -> Nothing
+            case break (=='/') ps of
+                ("","") -> Nothing
+                (seg,'/':ps1) -> Just (seg,ps1)
+                (seg,_) -> Just (seg,"")
 
 -- | Splits a 'URI' into its path components.
 pathSegments :: URI -> [String]


### PR DESCRIPTION
It appears that empty segments are ignored. For example: https://github.com/ChristopherKing42///network-uri goes to the same place as https://github.com/ChristopherKing42/network-uri

Still, this may be wanted.
